### PR TITLE
Update to use gtag.js

### DIFF
--- a/nf-ga.js
+++ b/nf-ga.js
@@ -15,7 +15,10 @@ var myGoogleAnalyticsController = Marionette.Object.extend( {
     triggerEvent: function( formTitle ) {
         console.log( 'trigger' );
         try {
-            ga('send', 'event', 'form', 'submit', formTitle );
+            gtag('event', 'submit', {
+                'event_category': 'form',
+                'event_label': formTitle
+            });
         } catch ( err ) {
             console.log( err );
         }


### PR DESCRIPTION
Google Analytics has updated the way they send Google Analytics events to use gtag.js. This is tested with all hundreds of clients' websites and is fully functional. Hence the suggestion to add this here!

Any issues please let us know